### PR TITLE
Fix Google Web Fonts CSS URLs so they work when HTML is served over HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,28 +13,28 @@
     	<title>Google Web Fonts Typographic Project</title>
 
         <!-- Google web Fonts -->
-        <link href='http://fonts.googleapis.com/css?family=Fauna+One|Oleo+Script|Fugaz+One|Monda|Unica+One|Alegreya:400italic,400|Abril+Fatface|Vollkorn' rel='stylesheet' type='text/css'>
+        <link href='//fonts.googleapis.com/css?family=Fauna+One|Oleo+Script|Fugaz+One|Monda|Unica+One|Alegreya:400italic,400|Abril+Fatface|Vollkorn' rel='stylesheet' type='text/css'>
 
         <!-- Google web fonts for "The Astronomer" -->
-        <link href='http://fonts.googleapis.com/css?family=Megrim|Roboto+Slab:300' rel='stylesheet' type='text/css'>
+        <link href='//fonts.googleapis.com/css?family=Megrim|Roboto+Slab:300' rel='stylesheet' type='text/css'>
 
         <!-- Google web fonts for "The River" -->
-        <link href='http://fonts.googleapis.com/css?family=Open+Sans:800|Gentium+Basic:400' rel='stylesheet' type='text/css'>
+        <link href='//fonts.googleapis.com/css?family=Open+Sans:800|Gentium+Basic:400' rel='stylesheet' type='text/css'>
 
         <!-- Google web fonts for "The Crow and the Pitcher" -->
-        <link href='http://fonts.googleapis.com/css?family=Questrial|Old+Standard+TT:400,400italic,700' rel='stylesheet' type='text/css'>
+        <link href='//fonts.googleapis.com/css?family=Questrial|Old+Standard+TT:400,400italic,700' rel='stylesheet' type='text/css'>
 
         <!-- Google web fonts for "The Fox and the Grapes" -->
-        <link href='http://fonts.googleapis.com/css?family=Ovo|Muli:300' rel='stylesheet' type='text/css'>
+        <link href='//fonts.googleapis.com/css?family=Ovo|Muli:300' rel='stylesheet' type='text/css'>
 
         <!-- Google web fonts for "The Moon and Her Mother: Anon03" -->
-        <link href='http://fonts.googleapis.com/css?family=Playfair+Display:400,700,900,400italic,700italic,900italic|Vast+Shadow|Oswald:300|Playfair+Display+SC' rel='stylesheet' type='text/css'>
+        <link href='//fonts.googleapis.com/css?family=Playfair+Display:400,700,900,400italic,700italic,900italic|Vast+Shadow|Oswald:300|Playfair+Display+SC' rel='stylesheet' type='text/css'>
         
         <!-- Google web fonts for "The Prophet" -->
-        <link href='http://fonts.googleapis.com/css?family=Neuton:300' rel='stylesheet' type='text/css'>
+        <link href='//fonts.googleapis.com/css?family=Neuton:300' rel='stylesheet' type='text/css'>
 
         <!-- Google web fonts for "The wolves, the sheep, and the ram" -->
-        <link href='http://fonts.googleapis.com/css?family=Quattrocento|Fanwood+Text' rel='stylesheet' type='text/css'>
+        <link href='//fonts.googleapis.com/css?family=Quattrocento|Fanwood+Text' rel='stylesheet' type='text/css'>
 
         <!-- Typography Project stylesheet -->
         <link href="css/google-type.css" rel="stylesheet">


### PR DESCRIPTION
Currently broken on https://femmebot.github.io/google-type/
