### PR TITLE
Twitter profile pic was missing

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,7 +217,7 @@
 
         <div class="container-fluid section-the-fox-and-the-grapes" id="twahlin">
           <div class="container">
-              <a href="https://twitter.com/twahlin" class="avatar" target="_blank" title="twahlin"><img src="https://pbs.twimg.com/profile_images/496783257283735552/OU3adCmn_400x400.jpeg" alt="twahlin"></a>
+              <a href="https://twitter.com/twahlin" class="avatar" target="_blank" title="twahlin"><img src="https://pbs.twimg.com/profile_images/616071869842747392/nH8Ts4l_.png" alt="twahlin"></a>
               <div class="caption"><a href="https://www.google.com/fonts/specimen/Ovo" target="_blank">Ovo</a>, <a href="https://www.google.com/fonts/specimen/Muli" target="_blank">Muli</a></div>
               <h2>The Fox &amp; the Grapes</h2>
               <p>A hungry Fox saw some fine bunches of Grapes hanging from a vine that was trained along a high trellis, and did his best to reach them by jumping as high as he could into the air. But it was all in vain, for they were just out of reach: so he gave up trying, and walked away with an air of dignity and unconcern, remarking, &ldquo;I thought those Grapes were ripe, but I see now they are quite sour.&rdquo;</p>


### PR DESCRIPTION
Most likely changed on Twitter. Perhaps local copies of profile images might work better, unless there is another way to dynamically update the src link when a person changes their Twitter pic.